### PR TITLE
Improve drum hit detection and add RGB feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ Desktop.ini
 *.workspace # General workspace files, can be from various tools
 *.suo       # Visual Studio Solution User Options
 *.sln.docstates # Visual Studio
+
+# For local testing and development only
+simulation/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This version is intended for Taiko Force Lv. 6 style drums and other two-player,
 ## Current Status
 
 - [x] Supports Taiko Force Lv. 6 drum wiring through ESP32-S3 ADC continuous mode with DMA.
-- [x] Supports two players.
+- [x] Processes two players; the current detector is calibrated against 1P data.
 - [x] Sends analog hit strength through gamepad axes instead of keyboard events.
 - [x] PCB Gerber files and BOM are available in [`PCB/`](./PCB/).
 - [x] [3D printed shell](./PCB/3D_Print_Shell.3mf) is ready.
@@ -25,21 +25,27 @@ Other ESP32 variants may work if they support the same ADC continuous mode, DMA 
 
 ## Firmware Overview
 
-The firmware in [`main/taiko_controller.c`](./main/taiko_controller.c) does four main things:
+The firmware in [`main/taiko_controller.c`](./main/taiko_controller.c) does six main things:
 
 1. Configures TinyUSB as a HID gamepad.
 2. Configures ADC continuous sampling for eight drum sensor inputs.
-3. Uses DMA frames to accumulate ADC samples at a stable rate.
-4. Converts recent per-zone signal power into signed gamepad axis values.
+3. Reassembles complete eight-channel scans independent of DMA frame boundaries.
+4. Converts raw ADC readings through an eFuse-calibrated millivolt lookup table.
+5. Runs baseline removal, a 0.96 ms RMS window, winner selection, and hit/rearm state through the platform-independent processor in [`main/taiko_hit_processor.c`](./main/taiko_hit_processor.c).
+6. Publishes the winning zone and strength through signed gamepad axes.
 
 The current sampling model is:
 
 - `PLAYERS`: `2`
 - `CHANNELS_PER_PLAYER`: `4`
 - `TOTAL_CHANNELS`: `8`
-- `PER_CHANNEL_SAMPLE_RATE_HZ`: `10000`
-- `USB_REPORT_INTERVAL_US`: `2000`
-- `POWER_RING_SIZE`: `3`
+- requested aggregate ADC rate: `83333` conversions/s
+- actual aggregate ADC rate: `83333.333` conversions/s
+- actual per-channel rate: `10416.667` samples/s
+- conversion spacing: `12 us`
+- `USB_REPORT_INTERVAL_US`: `1000`
+- detector integration and capture latency: about `1.73 ms`
+- output hold and refractory interval: `12 ms`
 
 Each player has four zones:
 
@@ -69,7 +75,7 @@ Debug outputs:
 
 | GPIO | Meaning |
 | --- | --- |
-| 1 | High when ADC read fails or times out |
+| 1 | High when the ADC DMA pool overflows or an ADC read fails |
 | 2 | High when the USB HID host is not ready |
 
 If you change pins, use ADC-capable pins for the selected ESP32-S3 board and keep GPIO 19/20 free for native USB unless your board routes USB differently.
@@ -161,28 +167,17 @@ Current axis mapping:
 | P2 | Right don | `+Ry` |
 | P2 | Right kat | `-Ry` |
 
-The firmware also pulses the gamepad Y button once per second so host-side tools can see that the controller is alive even when the drum is idle.
-
 ## Tuning
 
-The main tuning constants are currently in [`main/taiko_controller.c`](./main/taiko_controller.c):
-
-- `s_channel_sensitivity`: per-zone multipliers used to normalize piezo response.
-- `POWER_CLAMP`: signal power level that maps to the maximum gamepad axis value.
-- `POWER_RING_SIZE`: number of recent report windows used for peak hold.
-- `PER_CHANNEL_SAMPLE_RATE_HZ`: ADC sampling rate per channel.
-- `USB_REPORT_INTERVAL_US`: HID report interval.
-
-The default sensitivity array is:
+Choose the compile-time preset in [`main/taiko_controller.c`](./main/taiko_controller.c):
 
 ```c
-static float s_channel_sensitivity[TOTAL_CHANNELS] = {
-    1.0f, 15.0f, 1.0f, 15.0f,
-    1.0f, 15.0f, 1.0f, 15.0f,
-};
+#define HIT_SENSITIVITY TAIKO_SENSITIVITY_BALANCED
 ```
 
-Kat sensors are currently boosted relative to don sensors. You should expect to tune these values for your drum, sensor placement, shell material, and circuit.
+Available presets are `TAIKO_SENSITIVITY_SENSITIVE`, `TAIKO_SENSITIVITY_BALANCED`, and `TAIKO_SENSITIVITY_FIRM`. They differ in incidental-contact rejection and axis scaling; Balanced is the default. The thresholds and per-channel gains live in [`main/taiko_hit_processor.c`](./main/taiko_hit_processor.c).
+
+Only the 1P detector is currently calibrated. The existing P2 pins run the same processor, but the different P2 drum waveform needs its own capture and calibration before it should be treated as validated.
 
 ## Signal Conditioning Notes
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This version is intended for Taiko Force Lv. 6 style drums and other two-player,
 - [x] Sends analog hit strength through gamepad axes instead of keyboard events.
 - [x] PCB Gerber files and BOM are available in [`PCB/`](./PCB/).
 - [x] [3D printed shell](./PCB/3D_Print_Shell.3mf) is ready.
-- [ ] Misc firmware improvements under construction.
+- [x] Shows Don, Ka, and overlapping-hit feedback through the shared RGB LED.
 
 ## Hardware Support
 

--- a/README.md
+++ b/README.md
@@ -4,24 +4,25 @@
 
 # Taiko Drum Controller - ESP32-S3
 
-Open-source firmware and hardware for building a USB taiko drum controller for PC play.
+Open-source firmware and hardware for building a USB taiko drum controller for PC play. Note that this controller **does not support Taiko no Tatsujin: Rhythm Festival** or **TJAPlayer**. This project is intended for Nijiiro-style, arcade-like computers. Full support for Rhythm Festival/TJAPlayer/Nintendo Switch/Playstation 4 is planned.
 
-This version is intended for Taiko Force Lv. 6 style drums and other two-player, eight-sensor (1P x 4 + 2P x 4) taiko builds. For Taiko Force Lv. 5 and earlier versions, check the [archived branch](https://github.com/ShikyC/Taiko-Drum-Controller-Arduino/tree/archive-arduino-legacy).
+This version is intended for Taiko Force Lv. 4/5/6 drums. In theory it works with other custom-made drums, but I haven't done any verification yet.
 
 ## Current Status
 
 - [x] Supports Taiko Force Lv. 6 drum wiring through ESP32-S3 ADC continuous mode with DMA.
-- [x] Processes two players; the current detector is calibrated against 1P data.
+- [x] Processes two players with profiles calibrated against the supplied 1P and 2P captures.
 - [x] Sends analog hit strength through gamepad axes instead of keyboard events.
 - [x] PCB Gerber files and BOM are available in [`PCB/`](./PCB/).
 - [x] [3D printed shell](./PCB/3D_Print_Shell.3mf) is ready.
-- [x] Shows Don, Ka, and overlapping-hit feedback through the shared RGB LED.
+- [x] Shows status with the RGB LED.
+- [ ] Adds buttons for other PC games/Nintendo Switch/Playstation 4 support.
 
 ## Hardware Support
 
 The supported target is **ESP32-S3**.
 
-Other ESP32 variants may work if they support the same ADC continuous mode, DMA behavior, USB device mode, and pin availability, but they are not tested. Arduino boards, ATmega32U4 boards, and non-USB ESP32 development boards are not supported by this refactored firmware.
+Other ESP32 variants may work if they support the same ADC continuous mode, DMA behavior, USB device mode, and pin availability, but they are not tested. Arduino boards, ATmega32U4 boards, and non-USB ESP32 development boards are not supported by this firmware.
 
 ## Firmware Overview
 
@@ -46,16 +47,18 @@ The current sampling model is:
 - conversion spacing: `12 us`
 - `USB_REPORT_INTERVAL_US`: `1000`
 - detector integration and capture latency: about `1.73 ms`
-- output hold and refractory interval: `12 ms`
+- output hold: `12 ms`
+- standard-profile refractory interval: `12 ms`
+- long-tail-profile refractory interval: `72 ms`
 
 Each player has four zones:
 
 1. Left don
-2. Left kat
+2. Left ka
 3. Right don
-4. Right kat
+4. Right ka
 
-Only the strongest zone for each player is emitted in each HID report. Don zones are sent as positive axis values and kat zones are sent as negative axis values.
+Only the strongest zone for each player is emitted in each HID report. Don zones are sent as positive axis values and ka zones are sent as negative axis values.
 
 ## Pin Map
 
@@ -64,13 +67,13 @@ The default ADC pin map uses ADC1 GPIOs on ESP32-S3 and avoids the native USB pi
 | Player | Zone | GPIO |
 | --- | --- | --- |
 | P1 | Left don | 3 |
-| P1 | Left kat | 4 |
+| P1 | Left ka | 4 |
 | P1 | Right don | 5 |
-| P1 | Right kat | 6 |
+| P1 | Right ka | 6 |
 | P2 | Left don | 7 |
-| P2 | Left kat | 8 |
+| P2 | Left ka | 8 |
 | P2 | Right don | 9 |
-| P2 | Right kat | 10 |
+| P2 | Right ka | 10 |
 | Shared | RGB LED data | 38 |
 
 Debug outputs:
@@ -163,13 +166,13 @@ Current axis mapping:
 | Player | Zone | HID output |
 | --- | --- | --- |
 | P1 | Left don | `+X` |
-| P1 | Left kat | `-X` |
+| P1 | Left ka | `-X` |
 | P1 | Right don | `+Y` |
-| P1 | Right kat | `-Y` |
+| P1 | Right ka | `-Y` |
 | P2 | Left don | `+Rx` |
-| P2 | Left kat | `-Rx` |
+| P2 | Left ka | `-Rx` |
 | P2 | Right don | `+Ry` |
-| P2 | Right kat | `-Ry` |
+| P2 | Right ka | `-Ry` |
 
 ## Tuning
 
@@ -181,7 +184,16 @@ Choose the compile-time preset in [`main/taiko_controller.c`](./main/taiko_contr
 
 Available presets are `TAIKO_SENSITIVITY_SENSITIVE`, `TAIKO_SENSITIVITY_BALANCED`, and `TAIKO_SENSITIVITY_FIRM`. They differ in incidental-contact rejection and axis scaling; Balanced is the default. The thresholds and per-channel gains live in [`main/taiko_hit_processor.c`](./main/taiko_hit_processor.c).
 
-Only the 1P detector is currently calibrated. The existing P2 pins run the same processor, but the different P2 drum waveform needs its own capture and calibration before it should be treated as validated.
+Select the standard or long-tail processing profile independently for each drum:
+
+```c
+#define P1_USE_LONG_TAIL_PROFILE false
+#define P2_USE_LONG_TAIL_PROFILE true
+```
+
+The standard profile uses the selected sensitivity preset and a 12 ms refractory interval. The long-tail profile uses firm thresholds and a 72 ms refractory interval so that the noisier decay remains part of the original strike instead of becoming extra hits. The default selects the standard profile for P1 and the long-tail profile for P2. Profile selection only changes each processor's initialization data; it adds no work, task, or synchronization to the real-time ADC loop.
+
+Host replay tested 100 ADC start phases in both supported channel orders. The standard profile recognized all 6,400 phase-augmented 1P hits with no wrong zones, misses, or false positives; the long-tail profile did the same for all 6,400 2P hits. These captures contain isolated strikes. Because the 72 ms interval intentionally limits the long-tail profile to roughly 14 distinct hits per second per player, dense rolls should be recorded and added to the acceptance corpus before reducing it.
 
 ## Signal Conditioning Notes
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Other ESP32 variants may work if they support the same ADC continuous mode, DMA 
 
 ## Firmware Overview
 
-The firmware in [`main/taiko_controller.c`](./main/taiko_controller.c) does six main things:
+The firmware in [`main/taiko_controller.c`](./main/taiko_controller.c) does seven main things:
 
 1. Configures TinyUSB as a HID gamepad.
 2. Configures ADC continuous sampling for eight drum sensor inputs.
@@ -33,6 +33,7 @@ The firmware in [`main/taiko_controller.c`](./main/taiko_controller.c) does six 
 4. Converts raw ADC readings through an eFuse-calibrated millivolt lookup table.
 5. Runs baseline removal, a 0.96 ms RMS window, winner selection, and hit/rearm state through the platform-independent processor in [`main/taiko_hit_processor.c`](./main/taiko_hit_processor.c).
 6. Publishes the winning zone and strength through signed gamepad axes.
+7. Notifies a lower-priority, core-isolated RMT worker that drives the shared hit indicator without blocking ADC processing.
 
 The current sampling model is:
 
@@ -70,6 +71,7 @@ The default ADC pin map uses ADC1 GPIOs on ESP32-S3 and avoids the native USB pi
 | P2 | Left kat | 8 |
 | P2 | Right don | 9 |
 | P2 | Right kat | 10 |
+| Shared | RGB LED data | 38 |
 
 Debug outputs:
 
@@ -79,6 +81,8 @@ Debug outputs:
 | 2 | High when the USB HID host is not ready |
 
 If you change pins, use ADC-capable pins for the selected ESP32-S3 board and keep GPIO 19/20 free for native USB unless your board routes USB differently.
+
+The addressable RGB LED uses 24-bit `GRB` data. Each accepted Don hit holds red for 120 ms and each accepted Ka hit independently holds blue for 120 ms. If those windows overlap across either player, both channels remain active and the LED displays purple.
 
 ## Requirements
 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "taiko_controller.c"
+    SRCS "taiko_controller.c" "taiko_hit_processor.c"
     INCLUDE_DIRS "."
     PRIV_REQUIRES esp_adc esp_timer driver esp_driver_gpio
     )

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,13 @@
 idf_component_register(
-    SRCS "taiko_controller.c" "taiko_hit_processor.c"
+    SRCS
+        "taiko_controller.c"
+        "taiko_hit_led.c"
+        "taiko_hit_processor.c"
     INCLUDE_DIRS "."
-    PRIV_REQUIRES esp_adc esp_timer driver esp_driver_gpio
+    PRIV_REQUIRES
+        esp_adc
+        esp_timer
+        driver
+        esp_driver_gpio
+        esp_driver_rmt
     )

--- a/main/taiko_controller.c
+++ b/main/taiko_controller.c
@@ -53,6 +53,11 @@ enum {
 #define ADC_ATTEN_DB ADC_ATTEN_DB_12
 #define ADC_BIT_WIDTH ADC_BITWIDTH_12
 #define HIT_SENSITIVITY TAIKO_SENSITIVITY_BALANCED
+// Long-tail profile is only needed for old drums like Taiko Force Lv. 5 for
+// backward-compatibility. For newer models like Lv. 6 or other brands, this
+// is not needed.
+#define P1_USE_LONG_TAIL_PROFILE false
+#define P2_USE_LONG_TAIL_PROFILE false
 #define ADC_RAW_LEVELS (1U << 12)
 #define NOMINAL_ADC_FULL_SCALE_MV 3100U
 
@@ -72,6 +77,12 @@ typedef struct __attribute__((packed)) {
 static const int kChannelGpios[TOTAL_CHANNELS] = {
     3, 4, 5, 6,  // P1 L-Don, L-Ka, R-Don, R-Ka
     7, 8, 9, 10  // P2 L-Don, L-Ka, R-Don, R-Ka
+};
+
+// Select the 72 ms tail-suppression profile independently for each drum.
+static const bool kUseLongTailProfile[PLAYERS] = {
+    P1_USE_LONG_TAIL_PROFILE,
+    P2_USE_LONG_TAIL_PROFILE,
 };
 
 static adc_continuous_handle_t s_adc_handle;
@@ -427,9 +438,11 @@ void app_main(void) {
         sizeof(hid_string_descriptor) / sizeof(hid_string_descriptor[0]);
     ESP_ERROR_CHECK(tinyusb_driver_install(&tinyusb_config));
 
-    const taiko_hit_config_t hit_config =
-        taiko_hit_config_for_sensitivity(HIT_SENSITIVITY);
     for (int player = 0; player < PLAYERS; ++player) {
+        const taiko_hit_config_t hit_config =
+            kUseLongTailProfile[player]
+                ? taiko_hit_long_tail_config()
+                : taiko_hit_config_for_sensitivity(HIT_SENSITIVITY);
         taiko_hit_processor_init(&s_hit_processors[player], &hit_config);
     }
     // The indicator is deliberately optional; ADC and HID operation continues

--- a/main/taiko_controller.c
+++ b/main/taiko_controller.c
@@ -13,6 +13,7 @@
 #include "freertos/task.h"
 #include "hal/adc_types.h"
 #include "soc/soc_caps.h"
+#include "taiko_hit_led.h"
 #include "taiko_hit_processor.h"
 #include "tinyusb.h"
 #include "tinyusb_default_config.h"
@@ -261,8 +262,11 @@ static void process_complete_adc_scan(const uint16_t scan[TOTAL_CHANNELS]) {
     for (int player = 0; player < PLAYERS; ++player) {
         const uint16_t *player_samples =
             &scan[player * CHANNELS_PER_PLAYER];
-        taiko_hit_processor_push(
-            &s_hit_processors[player], player_samples, NULL);
+        taiko_hit_event_t hit_event;
+        if (taiko_hit_processor_push(
+                &s_hit_processors[player], player_samples, &hit_event)) {
+            taiko_hit_led_notify(hit_event.zone);
+        }
         const taiko_hit_output_t output =
             taiko_hit_processor_get_output(&s_hit_processors[player]);
         __atomic_store_n(
@@ -428,6 +432,9 @@ void app_main(void) {
     for (int player = 0; player < PLAYERS; ++player) {
         taiko_hit_processor_init(&s_hit_processors[player], &hit_config);
     }
+    // The indicator is deliberately optional; ADC and HID operation continues
+    // even if its low-priority worker cannot be created.
+    (void)taiko_hit_led_start();
 
     ESP_ERROR_CHECK(init_adc());
     init_adc_calibration_lut();

--- a/main/taiko_controller.c
+++ b/main/taiko_controller.c
@@ -1,31 +1,30 @@
-#include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+
 #include "class/hid/hid_device.h"
 #include "driver/gpio.h"
-
-#define DEBUG_PIN_1 GPIO_NUM_1  // HIGH if ADC read timeout
-#define DEBUG_PIN_2 GPIO_NUM_2  // HIGH if host not ready (tud_hid_ready false)
+#include "esp_adc/adc_cali.h"
+#include "esp_adc/adc_cali_scheme.h"
 #include "esp_adc/adc_continuous.h"
 #include "esp_heap_caps.h"
-#include "esp_log.h"
 #include "esp_timer.h"
-#include "rom/ets_sys.h"  // for esp_rom_delay_us
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "hal/adc_types.h"
 #include "soc/soc_caps.h"
+#include "taiko_hit_processor.h"
 #include "tinyusb.h"
 #include "tinyusb_default_config.h"
 
-// static const char *TAG = "taiko_gamepad"; // For debugging only
+#define DEBUG_PIN_1 GPIO_NUM_1  // HIGH on ADC DMA/read error
+#define DEBUG_PIN_2 GPIO_NUM_2  // HIGH while the USB HID host is not ready
 
 /************* TinyUSB descriptors ****************/
 
 enum {
     ITF_NUM_HID,
-    ITF_NUM_TOTAL
+    ITF_NUM_TOTAL,
 };
 
 #define EPNUM_HID 0x81
@@ -33,26 +32,28 @@ enum {
 
 #define USB_VID 0x4869
 #define USB_PID 0x4869
-#define USB_REPORT_INTERVAL_US 2000  // Must be multiple of 100 for integer samples
-#define AXIS_MAX 127
-#define AXIS_MIN (-127)
+#define USB_REPORT_INTERVAL_US 1000
 
-// ADC/DMA sampling + lightweight amplitude extraction
+/************* ADC and detector configuration ****************/
+
 #define PLAYERS 2
-#define CHANNELS_PER_PLAYER 4
+#define CHANNELS_PER_PLAYER TAIKO_CHANNELS_PER_PLAYER
 #define TOTAL_CHANNELS (PLAYERS * CHANNELS_PER_PLAYER)
-#define PER_CHANNEL_SAMPLE_RATE_HZ 10000UL
-// Derived: samples per CPU cycle = USB_REPORT_INTERVAL_US / 100
-#define SAMPLES_PER_CPU_CYCLE (USB_REPORT_INTERVAL_US / 100)
-#define DMA_CONVERSIONS_PER_FRAME (TOTAL_CHANNELS * SAMPLES_PER_CPU_CYCLE)
+
+// ESP32-S3's ADC digital controller uses a 2.5 MHz trigger timer. ESP-IDF
+// accepts 83,333 here, programs interval 30, and the resulting conversion
+// rate is 83,333.333 Hz (10,416.667 complete samples/s for each of 8 inputs).
+#define ADC_REQUESTED_CONVERSION_RATE_HZ 83333UL
+#define ADC_SCANS_PER_DMA_FRAME 8
+#define DMA_CONVERSIONS_PER_FRAME (TOTAL_CHANNELS * ADC_SCANS_PER_DMA_FRAME)
 #define DMA_FRAME_BYTES (DMA_CONVERSIONS_PER_FRAME * SOC_ADC_DIGI_RESULT_BYTES)
-#define DMA_STORE_BUFF_BYTES (DMA_FRAME_BYTES * 2)
-#define ADC_READ_TIMEOUT_MS 1
+#define DMA_STORE_BUFFER_BYTES (DMA_FRAME_BYTES * 8)
+#define ADC_READ_TIMEOUT_MS 2
 #define ADC_ATTEN_DB ADC_ATTEN_DB_12
 #define ADC_BIT_WIDTH ADC_BITWIDTH_12
-#define POWER_RING_SIZE 3
-
-#define BUTTON_Y_MASK (1u << 3)
+#define HIT_SENSITIVITY TAIKO_SENSITIVITY_BALANCED
+#define ADC_RAW_LEVELS (1U << 12)
+#define NOMINAL_ADC_FULL_SCALE_MV 3100U
 
 typedef struct __attribute__((packed)) {
     int8_t x;
@@ -65,33 +66,20 @@ typedef struct __attribute__((packed)) {
     uint32_t buttons;
 } taiko_hid_report_t;
 
-// ADC pin map (ADC1 GPIOs on ESP32-S3; avoids USB DP/DM pins 20/19)
+// Each player's four channels are contiguous. Within a player, mechanically
+// coupled same-side sensors are adjacent in the ADC pattern.
 static const int kChannelGpios[TOTAL_CHANNELS] = {
-    3, 4, 5, 6,  // P1 L-Don, L-Kat, R-Don, R-Kat
-    7, 8, 9, 10  // P2 L-Don, L-Kat, R-Don, R-Kat
+    3, 4, 5, 6,  // P1 L-Don, L-Ka, R-Don, R-Ka
+    7, 8, 9, 10  // P2 L-Don, L-Ka, R-Don, R-Ka
 };
 
 static adc_continuous_handle_t s_adc_handle;
 static TaskHandle_t s_adc_task_handle;
-static int8_t s_channel_index_by_adc[SOC_ADC_CHANNEL_NUM(0) + 1];
-
-// Double buffer for ADC accumulation (swap each CPU cycle for stable 10 samples)
-// Buffer 0 and 1 alternate: ADC writes to one while CPU reads the other
-static uint32_t s_adc_sums[2][TOTAL_CHANNELS];
-static volatile int s_adc_write_buf = 0;
-static portMUX_TYPE s_adc_mux = portMUX_INITIALIZER_UNLOCKED;
-
-// Ring buffer for power history (square of sum * sensitivity)
-static uint64_t s_power_ring[TOTAL_CHANNELS][POWER_RING_SIZE];
-static size_t s_power_ring_idx = 0;
-
-// Per-channel sensitivity scaler (tunable)
-static float s_channel_sensitivity[TOTAL_CHANNELS] = {
-    1.0f, 15.0f, 1.0f, 15.0f,
-    1.0f, 15.0f, 1.0f, 15.0f,
-};
-// Power clamp: values >= this map to max axis value
-static const uint64_t POWER_CLAMP = 10000000ULL;  // 1e7
+static int8_t s_pattern_slot_by_adc_channel[SOC_ADC_CHANNEL_NUM(0)];
+static volatile bool s_adc_pool_overflow;
+static taiko_hit_processor_t s_hit_processors[PLAYERS];
+static uint32_t s_published_outputs[PLAYERS];
+static uint16_t s_adc_millivolts[ADC_RAW_LEVELS];
 
 static const uint8_t hid_report_descriptor[] = {
     TUD_HID_REPORT_DESC_GAMEPAD(HID_REPORT_ID(0x01))
@@ -115,8 +103,10 @@ static const tusb_desc_device_t device_descriptor = {
 };
 
 static const uint8_t hid_configuration_descriptor[] = {
-    TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, TUSB_DESC_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
-    TUD_HID_DESCRIPTOR(ITF_NUM_HID, 4, false, sizeof(hid_report_descriptor), EPNUM_HID, sizeof(taiko_hid_report_t), 1),
+    TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, TUSB_DESC_TOTAL_LEN,
+                          TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
+    TUD_HID_DESCRIPTOR(ITF_NUM_HID, 4, false, sizeof(hid_report_descriptor),
+                       EPNUM_HID, sizeof(taiko_hid_report_t), 1),
 };
 
 static const char *hid_string_descriptor[] = {
@@ -134,7 +124,9 @@ uint8_t const *tud_hid_descriptor_report_cb(uint8_t instance) {
     return hid_report_descriptor;
 }
 
-uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t *buffer, uint16_t reqlen) {
+uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id,
+                               hid_report_type_t report_type, uint8_t *buffer,
+                               uint16_t reqlen) {
     (void)instance;
     (void)report_id;
     (void)report_type;
@@ -143,7 +135,9 @@ uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id, hid_report_t
     return 0;
 }
 
-void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t const *buffer, uint16_t bufsize) {
+void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id,
+                           hid_report_type_t report_type,
+                           uint8_t const *buffer, uint16_t bufsize) {
     (void)instance;
     (void)report_id;
     (void)report_type;
@@ -153,257 +147,318 @@ void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_
 
 /********* ADC continuous sampling ***************/
 
-static inline uint32_t frame_sample_freq_hz(void) {
-    return PER_CHANNEL_SAMPLE_RATE_HZ * TOTAL_CHANNELS;
-}
-
 static esp_err_t init_adc(void) {
     adc_continuous_handle_cfg_t handle_config = {
-        .max_store_buf_size = DMA_STORE_BUFF_BYTES,
+        .max_store_buf_size = DMA_STORE_BUFFER_BYTES,
         .conv_frame_size = DMA_FRAME_BYTES,
         .flags = {.flush_pool = 1},
     };
     ESP_ERROR_CHECK(adc_continuous_new_handle(&handle_config, &s_adc_handle));
 
     adc_digi_pattern_config_t pattern[TOTAL_CHANNELS] = {0};
-    memset(s_channel_index_by_adc, -1, sizeof(s_channel_index_by_adc));
+    memset(s_pattern_slot_by_adc_channel, -1,
+           sizeof(s_pattern_slot_by_adc_channel));
 
-    for (int i = 0; i < TOTAL_CHANNELS; ++i) {
+    for (int slot = 0; slot < TOTAL_CHANNELS; ++slot) {
         adc_unit_t unit;
-        adc_channel_t ch;
-        ESP_ERROR_CHECK(adc_continuous_io_to_channel(kChannelGpios[i], &unit, &ch));
-        s_channel_index_by_adc[ch] = i;
-        pattern[i].atten = ADC_ATTEN_DB;
-        pattern[i].channel = ch;
-        pattern[i].unit = unit;
-        pattern[i].bit_width = ADC_BIT_WIDTH;
+        adc_channel_t channel;
+        ESP_ERROR_CHECK(adc_continuous_io_to_channel(
+            kChannelGpios[slot], &unit, &channel));
+        if (unit != ADC_UNIT_1 || channel >= SOC_ADC_CHANNEL_NUM(0)) {
+            return ESP_ERR_INVALID_ARG;
+        }
+        s_pattern_slot_by_adc_channel[channel] = slot;
+        pattern[slot].atten = ADC_ATTEN_DB;
+        pattern[slot].channel = channel;
+        pattern[slot].unit = unit;
+        pattern[slot].bit_width = ADC_BIT_WIDTH;
     }
 
-    adc_continuous_config_t dig_cfg = {
+    adc_continuous_config_t digital_config = {
         .pattern_num = TOTAL_CHANNELS,
         .adc_pattern = pattern,
-        .sample_freq_hz = frame_sample_freq_hz(),
+        .sample_freq_hz = ADC_REQUESTED_CONVERSION_RATE_HZ,
         .conv_mode = ADC_CONV_SINGLE_UNIT_1,
         .format = ADC_DIGI_OUTPUT_FORMAT_TYPE2,
     };
-    ESP_ERROR_CHECK(adc_continuous_config(s_adc_handle, &dig_cfg));
+    ESP_ERROR_CHECK(adc_continuous_config(s_adc_handle, &digital_config));
     return ESP_OK;
 }
 
-static bool IRAM_ATTR on_conv_done_cb(adc_continuous_handle_t handle, const adc_continuous_evt_data_t *edata, void *user_data) {
+static void init_adc_calibration_lut(void) {
+    adc_cali_handle_t calibration = NULL;
+    const adc_cali_curve_fitting_config_t calibration_config = {
+        .unit_id = ADC_UNIT_1,
+        .chan = ADC_CHANNEL_0,
+        .atten = ADC_ATTEN_DB,
+        .bitwidth = ADC_BIT_WIDTH,
+    };
+    const bool calibrated =
+        adc_cali_create_scheme_curve_fitting(
+            &calibration_config, &calibration) == ESP_OK;
+
+    for (uint32_t raw = 0; raw < ADC_RAW_LEVELS; ++raw) {
+        int millivolts =
+            (int)((raw * NOMINAL_ADC_FULL_SCALE_MV +
+                   (ADC_RAW_LEVELS - 1U) / 2U) /
+                  (ADC_RAW_LEVELS - 1U));
+        if (calibrated) {
+            int calibrated_millivolts = 0;
+            if (adc_cali_raw_to_voltage(
+                    calibration, (int)raw, &calibrated_millivolts) == ESP_OK &&
+                calibrated_millivolts >= 0) {
+                millivolts = calibrated_millivolts;
+            }
+        }
+        s_adc_millivolts[raw] = (uint16_t)millivolts;
+    }
+}
+
+static bool IRAM_ATTR on_conversion_done(
+    adc_continuous_handle_t handle,
+    const adc_continuous_evt_data_t *event_data,
+    void *user_data) {
     (void)handle;
-    (void)edata;
+    (void)event_data;
     (void)user_data;
     BaseType_t awoken = pdFALSE;
     vTaskNotifyGiveFromISR(s_adc_task_handle, &awoken);
     return awoken == pdTRUE;
 }
 
-static void adc_reader_task(void *arg) {
-    uint8_t *raw = heap_caps_malloc(DMA_FRAME_BYTES, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
-    if (!raw) {
-        // ESP_LOGE(TAG, "no memory for ADC buffer");
+static bool IRAM_ATTR on_pool_overflow(
+    adc_continuous_handle_t handle,
+    const adc_continuous_evt_data_t *event_data,
+    void *user_data) {
+    (void)handle;
+    (void)event_data;
+    (void)user_data;
+    s_adc_pool_overflow = true;
+    BaseType_t awoken = pdFALSE;
+    vTaskNotifyGiveFromISR(s_adc_task_handle, &awoken);
+    return awoken == pdTRUE;
+}
+
+static uint32_t encode_output(taiko_hit_output_t output) {
+    if (!output.active) {
+        return 0;
+    }
+    return (1U << 31) | ((uint32_t)output.zone << 8) | output.axis_value;
+}
+
+static taiko_hit_output_t decode_output(uint32_t encoded) {
+    if ((encoded & (1U << 31)) == 0) {
+        return (taiko_hit_output_t){0};
+    }
+    return (taiko_hit_output_t){
+        .active = true,
+        .zone = (taiko_zone_t)((encoded >> 8) & 0xffU),
+        .axis_value = (uint8_t)(encoded & 0xffU),
+    };
+}
+
+static void process_complete_adc_scan(const uint16_t scan[TOTAL_CHANNELS]) {
+    for (int player = 0; player < PLAYERS; ++player) {
+        const uint16_t *player_samples =
+            &scan[player * CHANNELS_PER_PLAYER];
+        taiko_hit_processor_push(
+            &s_hit_processors[player], player_samples, NULL);
+        const taiko_hit_output_t output =
+            taiko_hit_processor_get_output(&s_hit_processors[player]);
+        __atomic_store_n(
+            &s_published_outputs[player], encode_output(output), __ATOMIC_RELEASE);
+    }
+}
+
+static void adc_reader_task(void *argument) {
+    (void)argument;
+    uint8_t *raw = heap_caps_malloc(
+        DMA_FRAME_BYTES, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
+    if (raw == NULL) {
+        gpio_set_level(DEBUG_PIN_1, 1);
         vTaskDelete(NULL);
         return;
     }
 
+    uint16_t scan[TOTAL_CHANNELS] = {0};
+    size_t expected_slot = 0;
+
     while (true) {
         ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
-        // Drain all available frames (non-blocking after first)
+        if (__atomic_exchange_n(
+                &s_adc_pool_overflow, false, __ATOMIC_ACQ_REL)) {
+            gpio_set_level(DEBUG_PIN_1, 1);
+        }
+
         bool first_read = true;
         while (true) {
-            uint32_t out = 0;
-            // First read can wait, subsequent reads are non-blocking
-            esp_err_t ret = adc_continuous_read(s_adc_handle, raw, DMA_FRAME_BYTES, &out,
-                                                 first_read ? ADC_READ_TIMEOUT_MS : 0);
+            uint32_t bytes_read = 0;
+            const esp_err_t result = adc_continuous_read(
+                s_adc_handle, raw, DMA_FRAME_BYTES, &bytes_read,
+                first_read ? ADC_READ_TIMEOUT_MS : 0);
             first_read = false;
-            if (ret == ESP_ERR_TIMEOUT || ret == ESP_ERR_INVALID_STATE) {
-                break;  // No more data available
-            }
-            gpio_set_level(DEBUG_PIN_1, ret == ESP_OK ? 0 : 1);  // LOW=ok, HIGH=error
-            if (ret != ESP_OK || out < SOC_ADC_DIGI_RESULT_BYTES) {
+
+            if (result == ESP_ERR_TIMEOUT) {
                 break;
             }
-
-            // Accumulate samples directly into sums
-            const adc_digi_output_data_t *items = (const adc_digi_output_data_t *)raw;
-            size_t convs = out / SOC_ADC_DIGI_RESULT_BYTES;
-
-            portENTER_CRITICAL(&s_adc_mux);
-            int buf = s_adc_write_buf;
-            for (size_t i = 0; i < convs; ++i) {
-                uint8_t adc_ch = items[i].type2.channel;
-                if (adc_ch >= (SOC_ADC_CHANNEL_NUM(0) + 1)) {
-                    continue;
-                }
-                int idx = s_channel_index_by_adc[adc_ch];
-                if (idx < 0 || idx >= TOTAL_CHANNELS) {
-                    continue;
-                }
-                s_adc_sums[buf][idx] += items[i].type2.data;
+            if (result != ESP_OK) {
+                gpio_set_level(DEBUG_PIN_1, 1);
+                expected_slot = 0;
+                break;
             }
-            portEXIT_CRITICAL(&s_adc_mux);
-        }
-    }
-}
+            gpio_set_level(DEBUG_PIN_1, 0);
 
-/********* Application ***************/
+            const adc_digi_output_data_t *items =
+                (const adc_digi_output_data_t *)raw;
+            const size_t conversions =
+                bytes_read / SOC_ADC_DIGI_RESULT_BYTES;
+            for (size_t index = 0; index < conversions; ++index) {
+                const uint8_t adc_channel = items[index].type2.channel;
+                if (adc_channel >= SOC_ADC_CHANNEL_NUM(0)) {
+                    expected_slot = 0;
+                    continue;
+                }
+                const int slot =
+                    s_pattern_slot_by_adc_channel[adc_channel];
+                if (slot < 0 || slot >= TOTAL_CHANNELS) {
+                    expected_slot = 0;
+                    continue;
+                }
 
-static int8_t clamp_axis(int32_t v) {
-    if (v > AXIS_MAX) {
-        return AXIS_MAX;
-    }
-    if (v < AXIS_MIN) {
-        return AXIS_MIN;
-    }
-    return (int8_t)v;
-}
+                // DMA reads can begin at any pattern position. Discard a
+                // partial scan and synchronize on slot zero.
+                if ((size_t)slot != expected_slot) {
+                    expected_slot = 0;
+                    if (slot != 0) {
+                        continue;
+                    }
+                }
 
-static taiko_hid_report_t consume_frames_and_build_report(void) {
-    // Swap buffers: ADC will write to the other buffer, we read from current
-    // This introduces 1ms latency but guarantees stable 10 samples per channel
-    portENTER_CRITICAL(&s_adc_mux);
-    int read_buf = s_adc_write_buf;
-    s_adc_write_buf = 1 - read_buf;
-    portEXIT_CRITICAL(&s_adc_mux);
-
-    // Calculate square of sum for each channel and store in ring buffer
-    for (int ch = 0; ch < TOTAL_CHANNELS; ++ch) {
-        uint64_t sum = s_adc_sums[read_buf][ch] * s_channel_sensitivity[ch];
-        s_power_ring[ch][s_power_ring_idx] = sum * sum;
-        s_adc_sums[read_buf][ch] = 0;
-    }
-    s_power_ring_idx = (s_power_ring_idx + 1) % POWER_RING_SIZE;
-
-    // Find max power from ring buffer for each channel
-    uint64_t max_power[TOTAL_CHANNELS];
-    for (int ch = 0; ch < TOTAL_CHANNELS; ++ch) {
-        max_power[ch] = 0;
-        for (int i = 0; i < POWER_RING_SIZE; ++i) {
-            if (s_power_ring[ch][i] > max_power[ch]) {
-                max_power[ch] = s_power_ring[ch][i];
+                const uint16_t raw_sample = items[index].type2.data;
+                scan[slot] =
+                    s_adc_millivolts[raw_sample < ADC_RAW_LEVELS
+                                         ? raw_sample
+                                         : ADC_RAW_LEVELS - 1U];
+                expected_slot++;
+                if (expected_slot == TOTAL_CHANNELS) {
+                    process_complete_adc_scan(scan);
+                    expected_slot = 0;
+                }
             }
         }
     }
-
-    // Map to axis values: clamp at POWER_CLAMP (1e7)
-    int32_t scaled_vals[TOTAL_CHANNELS];
-    for (int ch = 0; ch < TOTAL_CHANNELS; ++ch) {
-        if (max_power[ch] >= POWER_CLAMP) {
-            scaled_vals[ch] = AXIS_MAX;
-        } else {
-            scaled_vals[ch] = (int32_t)((max_power[ch] * AXIS_MAX) / POWER_CLAMP);
-        }
-    }
-
-    taiko_hid_report_t rpt = {0};
-    // For each drum, only the single highest channel fires; don = positive, kat = negative
-    // P1: find winner among L-Don(0), L-Kat(1), R-Don(2), R-Kat(3)
-    int p1_winner = 0;
-    for (int i = 1; i < 4; i++) {
-        if (scaled_vals[i] > scaled_vals[p1_winner]) p1_winner = i;
-    }
-    switch (p1_winner) {
-        case 0: rpt.x =  clamp_axis( scaled_vals[0]); break;  // L-Don → +x
-        case 1: rpt.x =  clamp_axis(-scaled_vals[1]); break;  // L-Kat → -x
-        case 2: rpt.y =  clamp_axis( scaled_vals[2]); break;  // R-Don → +y
-        case 3: rpt.y =  clamp_axis(-scaled_vals[3]); break;  // R-Kat → -y
-    }
-    // P2: find winner among L-Don(4), L-Kat(5), R-Don(6), R-Kat(7)
-    int p2_winner = 4;
-    for (int i = 5; i < 8; i++) {
-        if (scaled_vals[i] > scaled_vals[p2_winner]) p2_winner = i;
-    }
-    switch (p2_winner) {
-        case 4: rpt.rx = clamp_axis( scaled_vals[4]); break;  // L-Don → +rx
-        case 5: rpt.rx = clamp_axis(-scaled_vals[5]); break;  // L-Kat → -rx
-        case 6: rpt.ry = clamp_axis( scaled_vals[6]); break;  // R-Don → +ry
-        case 7: rpt.ry = clamp_axis(-scaled_vals[7]); break;  // R-Kat → -ry
-    }
-
-    // Pulse Y button at 1 Hz (0.5 s on / 0.5 s off) to keep some activity visible
-    uint32_t phase = esp_timer_get_time() % 1000000;
-    if (phase < 500000) {
-        rpt.buttons |= BUTTON_Y_MASK;
-    }
-
-    return rpt;
 }
 
-// Timer callback for HID reports (runs in esp_timer task context)
-static void hid_report_timer_cb(void *arg) {
-    (void)arg;
-    if (tud_mounted()) {
-        if (tud_suspended()) {
-            tud_remote_wakeup();
-        }
-        bool host_ready = tud_hid_ready();
-        gpio_set_level(DEBUG_PIN_2, host_ready ? 0 : 1);  // HIGH if not ready
+/********* HID report publication ***************/
 
-        if (host_ready) {
-            taiko_hid_report_t rpt = consume_frames_and_build_report();
-            tud_hid_report(0x01, &rpt, sizeof(rpt));
-        }
+static void apply_player_output(
+    taiko_hid_report_t *report, int player, taiko_hit_output_t output) {
+    if (!output.active || output.axis_value == 0) {
+        return;
+    }
+
+    int8_t *horizontal = player == 0 ? &report->x : &report->rx;
+    int8_t *vertical = player == 0 ? &report->y : &report->ry;
+    const int8_t value = (int8_t)output.axis_value;
+    switch (output.zone) {
+        case TAIKO_ZONE_LEFT_DON:
+            *horizontal = value;
+            break;
+        case TAIKO_ZONE_LEFT_KA:
+            *horizontal = -value;
+            break;
+        case TAIKO_ZONE_RIGHT_DON:
+            *vertical = value;
+            break;
+        case TAIKO_ZONE_RIGHT_KA:
+            *vertical = -value;
+            break;
+    }
+}
+
+static taiko_hid_report_t build_hid_report(void) {
+    taiko_hid_report_t report = {0};
+    for (int player = 0; player < PLAYERS; ++player) {
+        const uint32_t encoded = __atomic_load_n(
+            &s_published_outputs[player], __ATOMIC_ACQUIRE);
+        apply_player_output(&report, player, decode_output(encoded));
+    }
+    return report;
+}
+
+static void hid_report_timer_cb(void *argument) {
+    (void)argument;
+    if (!tud_mounted()) {
+        return;
+    }
+    if (tud_suspended()) {
+        tud_remote_wakeup();
+    }
+
+    const bool host_ready = tud_hid_ready();
+    gpio_set_level(DEBUG_PIN_2, host_ready ? 0 : 1);
+    if (host_ready) {
+        const taiko_hid_report_t report = build_hid_report();
+        tud_hid_report(0x01, &report, sizeof(report));
     }
 }
 
 void app_main(void) {
-    // Debug GPIOs for oscilloscope
-    // PIN_1: HIGH if ADC read timeout
-    // PIN_2: HIGH if host not ready (tud_hid_ready false)
-    gpio_config_t io_conf = {
-        .pin_bit_mask = (1ULL << DEBUG_PIN_1) | (1ULL << DEBUG_PIN_2),
+    const gpio_config_t debug_gpio_config = {
+        .pin_bit_mask =
+            (1ULL << DEBUG_PIN_1) | (1ULL << DEBUG_PIN_2),
         .mode = GPIO_MODE_OUTPUT,
         .pull_up_en = GPIO_PULLUP_DISABLE,
         .pull_down_en = GPIO_PULLDOWN_DISABLE,
         .intr_type = GPIO_INTR_DISABLE,
     };
-    gpio_config(&io_conf);
+    ESP_ERROR_CHECK(gpio_config(&debug_gpio_config));
 
-    // ESP_LOGI(TAG, "USB initialization (gamepad, VID 0x%04X PID 0x%04X)", USB_VID, USB_PID);
-    tinyusb_config_t tusb_cfg = TINYUSB_DEFAULT_CONFIG();
+    tinyusb_config_t tinyusb_config = TINYUSB_DEFAULT_CONFIG();
+    tinyusb_config.descriptor.device = &device_descriptor;
+    tinyusb_config.descriptor.full_speed_config =
+        hid_configuration_descriptor;
+    tinyusb_config.descriptor.string = hid_string_descriptor;
+    tinyusb_config.descriptor.string_count =
+        sizeof(hid_string_descriptor) / sizeof(hid_string_descriptor[0]);
+    ESP_ERROR_CHECK(tinyusb_driver_install(&tinyusb_config));
 
-    tusb_cfg.descriptor.device = &device_descriptor;
-    tusb_cfg.descriptor.full_speed_config = hid_configuration_descriptor;
-    tusb_cfg.descriptor.string = hid_string_descriptor;
-    tusb_cfg.descriptor.string_count = sizeof(hid_string_descriptor) / sizeof(hid_string_descriptor[0]);
-// #if TUD_OPT_HIGH_SPEED
-//     tusb_cfg.descriptor.high_speed_config = hid_configuration_descriptor;
-// #endif
+    const taiko_hit_config_t hit_config =
+        taiko_hit_config_for_sensitivity(HIT_SENSITIVITY);
+    for (int player = 0; player < PLAYERS; ++player) {
+        taiko_hit_processor_init(&s_hit_processors[player], &hit_config);
+    }
 
-    ESP_ERROR_CHECK(tinyusb_driver_install(&tusb_cfg));
-
-    // ESP_LOGI(TAG, "Setting up ADC DMA for %d channels @ %lu Hz per channel", TOTAL_CHANNELS, (unsigned long)PER_CHANNEL_SAMPLE_RATE_HZ);
     ESP_ERROR_CHECK(init_adc());
-
-    const UBaseType_t prio_adc = 3;
-    if (xTaskCreatePinnedToCore(adc_reader_task, "adc_reader", 4096, NULL, prio_adc, &s_adc_task_handle, 0) != pdPASS) {
-        // ESP_LOGE(TAG, "failed to start ADC reader task");
+    init_adc_calibration_lut();
+    const UBaseType_t adc_task_priority = 4;
+    if (xTaskCreatePinnedToCore(
+            adc_reader_task, "adc_reader", 4096, NULL, adc_task_priority,
+            &s_adc_task_handle, 0) != pdPASS) {
         return;
     }
 
-    adc_continuous_evt_cbs_t cbs = {
-        .on_conv_done = on_conv_done_cb,
-        .on_pool_ovf = NULL,
+    const adc_continuous_evt_cbs_t callbacks = {
+        .on_conv_done = on_conversion_done,
+        .on_pool_ovf = on_pool_overflow,
     };
-    ESP_ERROR_CHECK(adc_continuous_register_event_callbacks(s_adc_handle, &cbs, NULL));
+    ESP_ERROR_CHECK(
+        adc_continuous_register_event_callbacks(s_adc_handle, &callbacks, NULL));
     ESP_ERROR_CHECK(adc_continuous_start(s_adc_handle));
-    // ESP_LOGI(TAG, "ADC DMA started");
 
-    // Wait for ADC to fill first buffer before starting periodic reports
+    // Let the baseline estimator observe quiet samples before publishing.
     vTaskDelay(pdMS_TO_TICKS(2));
 
-    // Create precise 1ms periodic timer using hardware timer
     const esp_timer_create_args_t timer_args = {
         .callback = hid_report_timer_cb,
-        .dispatch_method = ESP_TIMER_TASK,  // Run in esp_timer task (not ISR)
+        .dispatch_method = ESP_TIMER_TASK,
         .name = "hid_report",
     };
     esp_timer_handle_t hid_timer;
     ESP_ERROR_CHECK(esp_timer_create(&timer_args, &hid_timer));
-    ESP_ERROR_CHECK(esp_timer_start_periodic(hid_timer, USB_REPORT_INTERVAL_US));
+    ESP_ERROR_CHECK(
+        esp_timer_start_periodic(hid_timer, USB_REPORT_INTERVAL_US));
 
-    // Main task can now sleep forever - timer handles HID reports
     while (true) {
         vTaskDelay(portMAX_DELAY);
     }

--- a/main/taiko_hit_led.c
+++ b/main/taiko_hit_led.c
@@ -1,0 +1,281 @@
+#include "taiko_hit_led.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "driver/gpio.h"
+#include "driver/rmt_tx.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#define HIT_LED_GPIO GPIO_NUM_38
+#define HIT_LED_HOLD_MS 120U
+#define HIT_LED_CHANNEL_LEVEL 96U
+#define HIT_LED_RMT_RESOLUTION_HZ 10000000U
+#define HIT_LED_RMT_SYMBOLS 64U
+#define HIT_LED_TX_TIMEOUT_MS 10
+#define HIT_LED_TASK_STACK_SIZE 3072U
+#define HIT_LED_TASK_PRIORITY 1U
+
+#ifdef CONFIG_FREERTOS_UNICORE
+#define HIT_LED_TASK_CORE 0
+#else
+#define HIT_LED_TASK_CORE 1
+#endif
+
+enum {
+    HIT_LED_EVENT_DON = 1U << 0,
+    HIT_LED_EVENT_KA = 1U << 1,
+};
+
+static const char *TAG = "taiko_hit_led";
+static TaskHandle_t s_hit_led_task_handle;
+
+// The supplied XL-5050RGBC-WS2812B datasheet identifies bits by their high
+// time. These values also keep the complete frame near its specified 800 kHz
+// data rate.
+static const DRAM_ATTR rmt_symbol_word_t kWs2812Zero = {
+    .level0 = 1,
+    .duration0 = 3,  // 0.3 us high
+    .level1 = 0,
+    .duration1 = 9,  // 0.9 us low
+};
+
+static const DRAM_ATTR rmt_symbol_word_t kWs2812One = {
+    .level0 = 1,
+    .duration0 = 9,  // 0.9 us high
+    .level1 = 0,
+    .duration1 = 3,  // 0.3 us low
+};
+
+static const DRAM_ATTR rmt_symbol_word_t kWs2812Reset = {
+    .level0 = 0,
+    .duration0 = 500,  // 50 us low
+    .level1 = 0,
+    .duration1 = 500,  // 50 us low
+};
+
+static size_t RMT_ENCODER_FUNC_ATTR encode_led_frame(
+    const void *data,
+    size_t data_size,
+    size_t symbols_written,
+    size_t symbols_free,
+    rmt_symbol_word_t *symbols,
+    bool *done,
+    void *argument) {
+    (void)argument;
+
+    // A byte needs eight symbols. Waiting for the same space before appending
+    // the reset symbol keeps the callback state derivable from symbols_written.
+    if (symbols_free < 8) {
+        return 0;
+    }
+
+    const size_t byte_index = symbols_written / 8;
+    if (byte_index < data_size) {
+        const uint8_t byte = ((const uint8_t *)data)[byte_index];
+        for (size_t bit = 0; bit < 8; ++bit) {
+            const uint8_t mask = (uint8_t)(0x80U >> bit);
+            symbols[bit] =
+                (byte & mask) != 0 ? kWs2812One : kWs2812Zero;
+        }
+        return 8;
+    }
+
+    // The datasheet asks for at least 100 us low, even though its timing table
+    // separately lists 80 us. Use the stricter value.
+    symbols[0] = kWs2812Reset;
+    *done = true;
+    return 1;
+}
+
+static esp_err_t init_led_rmt(rmt_channel_handle_t *channel,
+                              rmt_encoder_handle_t *encoder) {
+    const rmt_tx_channel_config_t channel_config = {
+        .gpio_num = HIT_LED_GPIO,
+        .clk_src = RMT_CLK_SRC_DEFAULT,
+        .resolution_hz = HIT_LED_RMT_RESOLUTION_HZ,
+        .mem_block_symbols = HIT_LED_RMT_SYMBOLS,
+        .trans_queue_depth = 1,
+        .intr_priority = 0,
+        .flags = {
+            .init_level = 0,
+        },
+    };
+    esp_err_t result = rmt_new_tx_channel(&channel_config, channel);
+    if (result != ESP_OK) {
+        return result;
+    }
+
+    const rmt_simple_encoder_config_t encoder_config = {
+        .callback = encode_led_frame,
+        .min_chunk_size = 8,
+    };
+    result = rmt_new_simple_encoder(&encoder_config, encoder);
+    if (result != ESP_OK) {
+        rmt_del_channel(*channel);
+        *channel = NULL;
+        return result;
+    }
+
+    result = rmt_enable(*channel);
+    if (result != ESP_OK) {
+        rmt_del_encoder(*encoder);
+        rmt_del_channel(*channel);
+        *encoder = NULL;
+        *channel = NULL;
+    }
+    return result;
+}
+
+static esp_err_t write_led_color(rmt_channel_handle_t channel,
+                                 rmt_encoder_handle_t encoder,
+                                 uint32_t active_colors) {
+    // The device consumes one pixel as G, R, B, most-significant bit first.
+    const uint8_t grb[3] = {
+        0,
+        (active_colors & HIT_LED_EVENT_DON) != 0
+            ? HIT_LED_CHANNEL_LEVEL
+            : 0,
+        (active_colors & HIT_LED_EVENT_KA) != 0
+            ? HIT_LED_CHANNEL_LEVEL
+            : 0,
+    };
+    const rmt_transmit_config_t transmit_config = {
+        .loop_count = 0,
+        .flags = {
+            .eot_level = 0,
+        },
+    };
+
+    esp_err_t result =
+        rmt_transmit(channel, encoder, grb, sizeof(grb), &transmit_config);
+    if (result == ESP_OK) {
+        result =
+            rmt_tx_wait_all_done(channel, HIT_LED_TX_TIMEOUT_MS);
+    }
+    return result;
+}
+
+static bool deadline_reached(TickType_t now, TickType_t deadline) {
+    return (int32_t)(now - deadline) >= 0;
+}
+
+static TickType_t next_deadline_wait(TickType_t now,
+                                     bool don_active,
+                                     TickType_t don_until,
+                                     bool ka_active,
+                                     TickType_t ka_until) {
+    TickType_t wait = portMAX_DELAY;
+    if (don_active) {
+        wait = don_until - now;
+    }
+    if (ka_active) {
+        const TickType_t ka_wait = ka_until - now;
+        if (wait == portMAX_DELAY || ka_wait < wait) {
+            wait = ka_wait;
+        }
+    }
+    return wait == 0 ? 1 : wait;
+}
+
+static void hit_led_task(void *argument) {
+    (void)argument;
+
+    // Initializing from this core also keeps the RMT interrupt off the
+    // core-0 ADC task.
+    rmt_channel_handle_t channel = NULL;
+    rmt_encoder_handle_t encoder = NULL;
+    const esp_err_t init_result = init_led_rmt(&channel, &encoder);
+    if (init_result != ESP_OK) {
+        ESP_LOGE(TAG, "indicator disabled: %s", esp_err_to_name(init_result));
+        __atomic_store_n(
+            &s_hit_led_task_handle, NULL, __ATOMIC_RELEASE);
+        vTaskDelete(NULL);
+        return;
+    }
+
+    bool don_active = false;
+    bool ka_active = false;
+    TickType_t don_until = 0;
+    TickType_t ka_until = 0;
+    uint32_t displayed_colors = UINT32_MAX;
+    uint32_t events = 0;
+    const TickType_t hold_ticks = pdMS_TO_TICKS(HIT_LED_HOLD_MS);
+
+    while (true) {
+        const TickType_t now = xTaskGetTickCount();
+        if ((events & HIT_LED_EVENT_DON) != 0) {
+            don_active = true;
+            don_until = now + hold_ticks;
+        }
+        if ((events & HIT_LED_EVENT_KA) != 0) {
+            ka_active = true;
+            ka_until = now + hold_ticks;
+        }
+
+        if (don_active && deadline_reached(now, don_until)) {
+            don_active = false;
+        }
+        if (ka_active && deadline_reached(now, ka_until)) {
+            ka_active = false;
+        }
+
+        const uint32_t active_colors =
+            (don_active ? HIT_LED_EVENT_DON : 0) |
+            (ka_active ? HIT_LED_EVENT_KA : 0);
+        if (active_colors != displayed_colors) {
+            const esp_err_t write_result =
+                write_led_color(channel, encoder, active_colors);
+            if (write_result != ESP_OK) {
+                ESP_LOGW(TAG, "color update failed: %s",
+                         esp_err_to_name(write_result));
+            }
+            displayed_colors = active_colors;
+        }
+
+        const TickType_t wait = next_deadline_wait(
+            now, don_active, don_until, ka_active, ka_until);
+        events = 0;
+        (void)xTaskNotifyWait(0, UINT32_MAX, &events, wait);
+    }
+}
+
+esp_err_t taiko_hit_led_start(void) {
+    if (__atomic_load_n(
+            &s_hit_led_task_handle, __ATOMIC_ACQUIRE) != NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (xTaskCreatePinnedToCore(
+            hit_led_task, "hit_led", HIT_LED_TASK_STACK_SIZE, NULL,
+            HIT_LED_TASK_PRIORITY, &s_hit_led_task_handle,
+            HIT_LED_TASK_CORE) != pdPASS) {
+        s_hit_led_task_handle = NULL;
+        ESP_LOGE(TAG, "indicator task could not be created");
+        return ESP_ERR_NO_MEM;
+    }
+    return ESP_OK;
+}
+
+void taiko_hit_led_notify(taiko_zone_t zone) {
+    uint32_t event = 0;
+    switch (zone) {
+        case TAIKO_ZONE_LEFT_DON:
+        case TAIKO_ZONE_RIGHT_DON:
+            event = HIT_LED_EVENT_DON;
+            break;
+        case TAIKO_ZONE_LEFT_KA:
+        case TAIKO_ZONE_RIGHT_KA:
+            event = HIT_LED_EVENT_KA;
+            break;
+    }
+
+    const TaskHandle_t task = __atomic_load_n(
+        &s_hit_led_task_handle, __ATOMIC_ACQUIRE);
+    if (event != 0 && task != NULL) {
+        (void)xTaskNotify(task, event, eSetBits);
+    }
+}

--- a/main/taiko_hit_led.h
+++ b/main/taiko_hit_led.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "esp_err.h"
+#include "taiko_hit_processor.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Starts the low-priority GPIO 38 indicator worker. LED failure is isolated
+// from hit detection, so callers may continue operating if this returns an
+// error.
+esp_err_t taiko_hit_led_start(void);
+
+// Nonblocking notification for a hit accepted by the detector. Don and Ka
+// use independent hold windows; when both are active the shared LED is purple.
+void taiko_hit_led_notify(taiko_zone_t zone);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/taiko_hit_processor.c
+++ b/main/taiko_hit_processor.c
@@ -6,6 +6,7 @@
 #define Q8_ONE 256U
 #define BASELINE_TRACK_SHIFT 10
 #define BASELINE_TRACK_MARGIN 36U
+#define LONG_TAIL_REFRACTORY_SAMPLES 750U
 
 static uint32_t integer_sqrt_u64(uint64_t value) {
     uint64_t bit = 1ULL << 62;
@@ -86,6 +87,17 @@ taiko_hit_config_t taiko_hit_config_for_sensitivity(
 
 taiko_hit_config_t taiko_hit_default_config(void) {
     return taiko_hit_config_for_sensitivity(TAIKO_SENSITIVITY_BALANCED);
+}
+
+taiko_hit_config_t taiko_hit_long_tail_config(void) {
+    taiko_hit_config_t config =
+        taiko_hit_config_for_sensitivity(TAIKO_SENSITIVITY_FIRM);
+
+    // At 10,416.667 complete scans/s this is 72 ms. The longer interval keeps
+    // a noisy drum's decaying waveform inside the original hit while leaving
+    // the output latch at 12 ms.
+    config.refractory_samples = LONG_TAIL_REFRACTORY_SAMPLES;
+    return config;
 }
 
 void taiko_hit_processor_init(taiko_hit_processor_t *processor,

--- a/main/taiko_hit_processor.c
+++ b/main/taiko_hit_processor.c
@@ -1,0 +1,273 @@
+#include "taiko_hit_processor.h"
+
+#include <limits.h>
+#include <string.h>
+
+#define Q8_ONE 256U
+#define BASELINE_TRACK_SHIFT 10
+#define BASELINE_TRACK_MARGIN 36U
+
+static uint32_t integer_sqrt_u64(uint64_t value) {
+    uint64_t bit = 1ULL << 62;
+    uint64_t result = 0;
+
+    while (bit > value) {
+        bit >>= 2;
+    }
+    while (bit != 0) {
+        if (value >= result + bit) {
+            value -= result + bit;
+            result = (result >> 1) + bit;
+        } else {
+            result >>= 1;
+        }
+        bit >>= 2;
+    }
+    return result > UINT32_MAX ? UINT32_MAX : (uint32_t)result;
+}
+
+static uint8_t level_to_axis(const taiko_hit_config_t *config, uint16_t level) {
+    if (level >= config->full_scale_level) {
+        return 127;
+    }
+    if (level <= config->trigger_level ||
+        config->full_scale_level <= config->trigger_level) {
+        return config->minimum_axis;
+    }
+
+    const uint32_t input_range = config->full_scale_level - config->trigger_level;
+    const uint32_t output_range = 127U - config->minimum_axis;
+    const uint32_t scaled =
+        ((uint32_t)(level - config->trigger_level) * output_range + input_range / 2U) /
+        input_range;
+    return (uint8_t)(config->minimum_axis + scaled);
+}
+
+taiko_hit_config_t taiko_hit_config_for_sensitivity(
+    taiko_sensitivity_t sensitivity) {
+    taiko_hit_config_t config = {
+        .noise_floor = 18,
+        .trigger_level = 68,
+        .release_level = 34,
+        .full_scale_level = 1360,
+        .channel_gain_q8 = {
+            Q8_ONE,
+            2U * Q8_ONE,
+            Q8_ONE,
+            (3U * Q8_ONE) / 2U,
+        },
+        .integration_samples = 10,
+        .capture_samples = 8,
+        .refractory_samples = 125,
+        .rearm_samples = 16,
+        .output_hold_samples = 125,
+        .minimum_axis = 8,
+    };
+
+    switch (sensitivity) {
+        case TAIKO_SENSITIVITY_SENSITIVE:
+            config.noise_floor = 12;
+            config.trigger_level = 53;
+            config.release_level = 27;
+            config.full_scale_level = 1135;
+            break;
+        case TAIKO_SENSITIVITY_FIRM:
+            config.noise_floor = 24;
+            config.trigger_level = 98;
+            config.release_level = 49;
+            config.full_scale_level = 1665;
+            break;
+        case TAIKO_SENSITIVITY_BALANCED:
+        default:
+            break;
+    }
+    return config;
+}
+
+taiko_hit_config_t taiko_hit_default_config(void) {
+    return taiko_hit_config_for_sensitivity(TAIKO_SENSITIVITY_BALANCED);
+}
+
+void taiko_hit_processor_init(taiko_hit_processor_t *processor,
+                              const taiko_hit_config_t *config) {
+    memset(processor, 0, sizeof(*processor));
+    processor->config = config != NULL ? *config : taiko_hit_default_config();
+
+    if (processor->config.integration_samples == 0) {
+        processor->config.integration_samples = 1;
+    } else if (processor->config.integration_samples > TAIKO_MAX_INTEGRATION_SAMPLES) {
+        processor->config.integration_samples = TAIKO_MAX_INTEGRATION_SAMPLES;
+    }
+    if (processor->config.capture_samples == 0) {
+        processor->config.capture_samples = 1;
+    }
+    if (processor->config.rearm_samples == 0) {
+        processor->config.rearm_samples = 1;
+    }
+    if (processor->config.output_hold_samples == 0) {
+        processor->config.output_hold_samples = 1;
+    }
+    if (processor->config.full_scale_level <= processor->config.trigger_level) {
+        processor->config.full_scale_level = processor->config.trigger_level + 1;
+    }
+    if (processor->config.minimum_axis == 0) {
+        processor->config.minimum_axis = 1;
+    } else if (processor->config.minimum_axis > 127) {
+        processor->config.minimum_axis = 127;
+    }
+}
+
+static void update_output_hold(taiko_hit_processor_t *processor) {
+    if (processor->output_remaining == 0) {
+        processor->output.active = false;
+        processor->output.axis_value = 0;
+        return;
+    }
+    processor->output_remaining--;
+    if (processor->output_remaining == 0) {
+        processor->output.active = false;
+        processor->output.axis_value = 0;
+    }
+}
+
+static void update_baselines_and_levels(
+    taiko_hit_processor_t *processor,
+    const uint16_t samples[TAIKO_CHANNELS_PER_PLAYER],
+    uint16_t levels[TAIKO_CHANNELS_PER_PLAYER]) {
+    if (!processor->baseline_initialized) {
+        for (size_t channel = 0; channel < TAIKO_CHANNELS_PER_PLAYER; ++channel) {
+            processor->baseline_q8[channel] = (int32_t)samples[channel] << 8;
+        }
+        processor->baseline_initialized = true;
+    }
+
+    const uint8_t integration_samples = processor->config.integration_samples;
+    for (size_t channel = 0; channel < TAIKO_CHANNELS_PER_PLAYER; ++channel) {
+        const int32_t raw_q8 = (int32_t)samples[channel] << 8;
+        const uint16_t baseline = (uint16_t)(processor->baseline_q8[channel] >> 8);
+
+        if (samples[channel] <= baseline + BASELINE_TRACK_MARGIN) {
+            processor->baseline_q8[channel] +=
+                (raw_q8 - processor->baseline_q8[channel]) >> BASELINE_TRACK_SHIFT;
+        }
+
+        uint32_t amplitude =
+            samples[channel] > baseline ? (uint32_t)samples[channel] - baseline : 0;
+        amplitude =
+            amplitude > processor->config.noise_floor
+                ? amplitude - processor->config.noise_floor
+                : 0;
+        amplitude =
+            (amplitude * processor->config.channel_gain_q8[channel] + Q8_ONE / 2U) /
+            Q8_ONE;
+
+        const uint64_t energy = (uint64_t)amplitude * amplitude;
+        processor->energy_sum[channel] -=
+            processor->energy_ring[channel][processor->ring_index];
+        processor->energy_ring[channel][processor->ring_index] = energy;
+        processor->energy_sum[channel] += energy;
+
+        const uint8_t divisor =
+            processor->ring_count < integration_samples
+                ? (uint8_t)(processor->ring_count + 1)
+                : integration_samples;
+        uint32_t level = integer_sqrt_u64(processor->energy_sum[channel] / divisor);
+        levels[channel] = level > UINT16_MAX ? UINT16_MAX : (uint16_t)level;
+    }
+
+    processor->ring_index = (uint8_t)((processor->ring_index + 1) % integration_samples);
+    if (processor->ring_count < integration_samples) {
+        processor->ring_count++;
+    }
+}
+
+static taiko_zone_t find_winner(const uint16_t levels[TAIKO_CHANNELS_PER_PLAYER],
+                                uint16_t *winning_level) {
+    taiko_zone_t winner = TAIKO_ZONE_LEFT_DON;
+    for (size_t channel = 1; channel < TAIKO_CHANNELS_PER_PLAYER; ++channel) {
+        if (levels[channel] > levels[winner]) {
+            winner = (taiko_zone_t)channel;
+        }
+    }
+    *winning_level = levels[winner];
+    return winner;
+}
+
+static bool emit_candidate(taiko_hit_processor_t *processor, taiko_hit_event_t *event) {
+    const uint8_t axis_value =
+        level_to_axis(&processor->config, processor->candidate_level);
+    processor->output = (taiko_hit_output_t){
+        .active = true,
+        .zone = processor->candidate_zone,
+        .axis_value = axis_value,
+    };
+    processor->output_remaining = processor->config.output_hold_samples;
+    processor->detector_state = TAIKO_DETECTOR_REFRACTORY;
+    processor->refractory_remaining = processor->config.refractory_samples;
+    processor->quiet_samples = 0;
+
+    if (event != NULL) {
+        *event = (taiko_hit_event_t){
+            .zone = processor->candidate_zone,
+            .axis_value = axis_value,
+            .level = processor->candidate_level,
+        };
+    }
+    return true;
+}
+
+bool taiko_hit_processor_push(taiko_hit_processor_t *processor,
+                              const uint16_t samples[TAIKO_CHANNELS_PER_PLAYER],
+                              taiko_hit_event_t *event) {
+    update_output_hold(processor);
+
+    uint16_t levels[TAIKO_CHANNELS_PER_PLAYER];
+    update_baselines_and_levels(processor, samples, levels);
+
+    uint16_t winning_level = 0;
+    const taiko_zone_t winner = find_winner(levels, &winning_level);
+
+    switch (processor->detector_state) {
+        case TAIKO_DETECTOR_IDLE:
+            if (winning_level >= processor->config.trigger_level) {
+                processor->detector_state = TAIKO_DETECTOR_CAPTURE;
+                processor->capture_remaining = processor->config.capture_samples;
+                processor->candidate_zone = winner;
+                processor->candidate_level = winning_level;
+            }
+            break;
+
+        case TAIKO_DETECTOR_CAPTURE:
+            if (winning_level > processor->candidate_level) {
+                processor->candidate_zone = winner;
+                processor->candidate_level = winning_level;
+            }
+            if (--processor->capture_remaining == 0) {
+                return emit_candidate(processor, event);
+            }
+            break;
+
+        case TAIKO_DETECTOR_REFRACTORY:
+            if (processor->refractory_remaining > 0) {
+                processor->refractory_remaining--;
+            }
+            if (winning_level <= processor->config.release_level) {
+                if (processor->quiet_samples < UINT8_MAX) {
+                    processor->quiet_samples++;
+                }
+            } else {
+                processor->quiet_samples = 0;
+            }
+            if (processor->refractory_remaining == 0 &&
+                processor->quiet_samples >= processor->config.rearm_samples) {
+                processor->detector_state = TAIKO_DETECTOR_IDLE;
+            }
+            break;
+    }
+
+    return false;
+}
+
+taiko_hit_output_t taiko_hit_processor_get_output(const taiko_hit_processor_t *processor) {
+    return processor->output;
+}

--- a/main/taiko_hit_processor.h
+++ b/main/taiko_hit_processor.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TAIKO_CHANNELS_PER_PLAYER 4
+#define TAIKO_MAX_INTEGRATION_SAMPLES 16
+
+typedef enum {
+    TAIKO_ZONE_LEFT_DON = 0,
+    TAIKO_ZONE_LEFT_KA = 1,
+    TAIKO_ZONE_RIGHT_DON = 2,
+    TAIKO_ZONE_RIGHT_KA = 3,
+} taiko_zone_t;
+
+typedef enum {
+    TAIKO_SENSITIVITY_SENSITIVE = 0,
+    TAIKO_SENSITIVITY_BALANCED,
+    TAIKO_SENSITIVITY_FIRM,
+} taiko_sensitivity_t;
+
+typedef struct {
+    uint16_t noise_floor;
+    uint16_t trigger_level;
+    uint16_t release_level;
+    uint16_t full_scale_level;
+    uint16_t channel_gain_q8[TAIKO_CHANNELS_PER_PLAYER];
+    uint8_t integration_samples;
+    uint8_t capture_samples;
+    uint16_t refractory_samples;
+    uint8_t rearm_samples;
+    uint16_t output_hold_samples;
+    uint8_t minimum_axis;
+} taiko_hit_config_t;
+
+typedef struct {
+    taiko_zone_t zone;
+    uint8_t axis_value;
+    uint16_t level;
+} taiko_hit_event_t;
+
+typedef struct {
+    bool active;
+    taiko_zone_t zone;
+    uint8_t axis_value;
+} taiko_hit_output_t;
+
+typedef enum {
+    TAIKO_DETECTOR_IDLE = 0,
+    TAIKO_DETECTOR_CAPTURE,
+    TAIKO_DETECTOR_REFRACTORY,
+} taiko_detector_state_t;
+
+typedef struct {
+    taiko_hit_config_t config;
+    int32_t baseline_q8[TAIKO_CHANNELS_PER_PLAYER];
+    uint64_t energy_ring[TAIKO_CHANNELS_PER_PLAYER][TAIKO_MAX_INTEGRATION_SAMPLES];
+    uint64_t energy_sum[TAIKO_CHANNELS_PER_PLAYER];
+    uint8_t ring_index;
+    uint8_t ring_count;
+    bool baseline_initialized;
+
+    taiko_detector_state_t detector_state;
+    uint8_t capture_remaining;
+    uint16_t refractory_remaining;
+    uint8_t quiet_samples;
+    taiko_zone_t candidate_zone;
+    uint16_t candidate_level;
+
+    taiko_hit_output_t output;
+    uint16_t output_remaining;
+} taiko_hit_processor_t;
+
+taiko_hit_config_t taiko_hit_config_for_sensitivity(
+    taiko_sensitivity_t sensitivity);
+taiko_hit_config_t taiko_hit_default_config(void);
+void taiko_hit_processor_init(taiko_hit_processor_t *processor,
+                              const taiko_hit_config_t *config);
+bool taiko_hit_processor_push(taiko_hit_processor_t *processor,
+                              const uint16_t samples[TAIKO_CHANNELS_PER_PLAYER],
+                              taiko_hit_event_t *event);
+taiko_hit_output_t taiko_hit_processor_get_output(const taiko_hit_processor_t *processor);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/taiko_hit_processor.h
+++ b/main/taiko_hit_processor.h
@@ -78,6 +78,7 @@ typedef struct {
 
 taiko_hit_config_t taiko_hit_config_for_sensitivity(
     taiko_sensitivity_t sensitivity);
+taiko_hit_config_t taiko_hit_long_tail_config(void);
 taiko_hit_config_t taiko_hit_default_config(void);
 void taiko_hit_processor_init(taiko_hit_processor_t *processor,
                               const taiko_hit_config_t *config);


### PR DESCRIPTION
## Summary

- replace the legacy raw-power detector with calibrated millivolt sampling, complete eight-channel scan reconstruction, baseline removal, a sliding RMS window, winner capture, refractory/rearm handling, and sensitivity presets
- share the detector implementation between the ESP32-S3 firmware and local capture regression tooling while keeping simulation data and tools out of the published source tree
- increase HID publication to 1 kHz and preserve a 12 ms output hold so accepted hits remain visible to the game input path
- add a shared GPIO 38 addressable RGB hit indicator: Don holds red for 120 ms, Ka holds blue for 120 ms, and overlapping windows across either player display purple
- isolate LED work in a priority-1 FreeRTOS task on core 1 using the RMT peripheral; the priority-4 ADC task only sends nonblocking event bits
- update the README with the implemented timing model, tuning presets, pin map, and completed RGB-indicator status

## Why

The previous detector summed raw ADC values, heavily boosted Ka channels, squared the result, and lacked proper baseline, trigger, and rearm states. That made DC offset and mechanical coupling dominate the output, reducing useful dynamic range and allowing cross-zone noise or ringing to look like hits. The controller also had no direct visual indication of accepted Don and Ka events.

## Impact

Hit processing now chooses one clean winning zone per player, exposes a wider analog strength range, suppresses ringing and coupled-sensor ghost hits, and provides immediate shared LED feedback without adding blocking work to the ADC path. The current thresholds are calibrated against the available 1P capture; P2 uses the same processor but still needs its own waveform capture and calibration.

## Validation

- `idf.py build` with ESP-IDF 5.5.2 for ESP32-S3
- host processor unit tests
- complete 100-phase capture regression matrix: 6,400 expected hits, 6,400 correct zones, no misses, wrong zones, or false positives
- flashed to the connected ESP32-S3 with bootloader, partition, and application hashes verified
- hardware smoke check confirmed the RGB hit feedback behaves as intended
